### PR TITLE
fix: remove public GET /users endpoint that leaked all user emails

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -38,12 +38,6 @@ def register(user: UserIn):
     db.refresh(new_user)
     return {"message": "User registered", "user": user}
 
-@app.get("/users")
-def get_users():
-    db: Session = database.SessionLocal()
-    users = db.query(models.User).all()
-    return {"users": users}
-
 @app.delete("/users/{user_id}")
 def delete_user(user_id: int):
     db: Session = database.SessionLocal()


### PR DESCRIPTION
## Summary
- Remove the unauthenticated `GET /users` endpoint, which returned every registered user's email and unit preference to any caller.

## Context
The endpoint had no auth, no rate limiting, and was reachable directly from the public internet. The frontend doesn't call it. Removing is the smallest safe fix; if it's needed later it can come back behind an admin token or behind `/admin` with a separate router.

## Changes
- `app/main.py`: delete the `@app.get("/users")` handler.

## Test plan
- [ ] Redeploy to Fly.io.
- [ ] `curl https://voyager2-reminder.fly.dev/users` → expect 404.
- [ ] `POST /register` still works.
- [ ] Existing scheduled email job still fires (it doesn't depend on `GET /users`).

## Follow-up (out of scope here)
- `GET /users/{id}`, `DELETE /users/{id}`, and `POST /users/{id}/notify` are also unauthenticated and abusable; consider gating them behind an admin token in a follow-up PR.