### PR TITLE
fix: prevent boot crash and make data persist across deploys

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -1,7 +1,9 @@
+import os
+
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, declarative_base
 
-SQLALCHEMY_DATABASE_URL = "sqlite:///./data/users.db"
+SQLALCHEMY_DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:////data/users.db")
 
 engine = create_engine(SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False})
 SessionLocal = sessionmaker(bind=engine)

--- a/app/emailer.py
+++ b/app/emailer.py
@@ -7,7 +7,7 @@ import os
 load_dotenv()
 
 SMTP_HOST = os.getenv("SMTP_HOST")
-SMTP_PORT = int(os.getenv("SMTP_PORT"))
+SMTP_PORT = int(os.getenv("SMTP_PORT") or 587)
 SMTP_USER = os.getenv("SMTP_USER")
 SMTP_PASS = os.getenv("SMTP_PASS")
 FROM_EMAIL = os.getenv("FROM_EMAIL")

--- a/env.example
+++ b/env.example
@@ -1,26 +1,12 @@
-# Email Configuration
-SMTP_SERVER=smtp.gmail.com
+# SMTP / Email (read by app/emailer.py)
+SMTP_HOST=smtp.gmail.com
 SMTP_PORT=587
-EMAIL_ADDRESS=your-email@gmail.com
-EMAIL_PASSWORD=your-app-password
+SMTP_USER=your-email@gmail.com
+SMTP_PASS=your-app-password
+FROM_EMAIL=your-email@gmail.com
 
-# API Configuration
-API_HOST=0.0.0.0
-API_PORT=8080
-
-# Database Configuration
-DATABASE_URL=sqlite:///./data/users.db
-
-# Scheduler Configuration
-SCHEDULER_INTERVAL_MINUTES=60
-
-# Voyager 2 API Configuration (if applicable)
-VOYAGER_API_URL=https://api.nasa.gov/voyager
-
-# Development/Debug Settings
-DEBUG=False
-LOG_LEVEL=INFO
-
-# Optional: Email Templates
-EMAIL_FROM_NAME="Voyager 2 Reminder"
-EMAIL_SUBJECT_PREFIX="[Voyager 2]" 
+# Database (read by app/database.py)
+# Default for Fly.io with the mounted "db" volume:
+DATABASE_URL=sqlite:////data/users.db
+# For local development, use a relative path instead:
+# DATABASE_URL=sqlite:///./data/users.db


### PR DESCRIPTION
## Summary
- `app/database.py` now reads `DATABASE_URL` env var (default `sqlite:////data/users.db`) so the Fly volume mount actually gets used and users persist across deploys.
- `app/emailer.py` no longer crashes on import when `SMTP_PORT` is unset (was `int(None) → TypeError` → boot loop → no machines).
- `env.example` renamed SMTP vars to match what the code actually reads.

## Context
Investigating why \`voyager2-reminder.fly.dev\` was failing TLS handshake with no machines visible. Root cause was bug #2 above: with email secrets missing, the FastAPI app crashed on import, machines never came up healthy, and Fly eventually had no live machines. Bug #1 was a separate latent issue (data wasn't actually persisting). Bug #3 was a documentation drift that probably caused both #1 and #2 in the first place.

## Changes
- `app/database.py`: import os; read DATABASE_URL with absolute-path default for the mounted volume.
- `app/emailer.py`: `int(os.getenv("SMTP_PORT") or 587)`.
- `env.example`: rewrote to match the actual variable names in code.

## Test plan
- [ ] `fly secrets set SMTP_HOST=smtp.gmail.com SMTP_USER=... SMTP_PASS=... FROM_EMAIL=... -a voyager2-reminder` (do this in a real terminal — don't paste secrets into chat)
- [ ] `fly deploy` from this branch / from main once merged
- [ ] `fly logs -a voyager2-reminder` should show clean uvicorn boot, no TypeError
- [ ] `curl https://voyager2-reminder.fly.dev/jobs` returns 200 with the scheduler job
- [ ] From the live frontend on DigitalOcean, submit a registration → 200 + email arrives