### PR TITLE
feat: require email confirmation before sending notifications

### DIFF
--- a/app/emailer.py
+++ b/app/emailer.py
@@ -97,6 +97,47 @@ def create_html_template(unit, distance_km):
     """
     return html_template
 
+def send_verification_email(to_email, verify_url):
+    """Send a confirmation email with a one-click verify link."""
+    msg = MIMEMultipart("alternative")
+    msg["Subject"] = "Confirm your Voyager 2 subscription"
+    msg["From"] = FROM_EMAIL
+    msg["To"] = to_email
+
+    html = f"""
+    <!DOCTYPE html>
+    <html>
+    <body style="font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; background: #0a0a0a; color: #fff; margin: 0; padding: 40px 20px;">
+        <div style="max-width: 480px; margin: 0 auto; background: rgba(255,255,255,0.05); border-radius: 16px; padding: 40px 30px; text-align: center;">
+            <div style="font-size: 48px; margin-bottom: 10px;">🚀</div>
+            <h1 style="margin: 0 0 20px 0; font-size: 22px; font-weight: 300; letter-spacing: 1px;">Confirm your subscription</h1>
+            <p style="font-size: 15px; opacity: 0.85; line-height: 1.6;">
+                Click below to confirm you want Voyager 2 distance updates.
+                You won't get any further emails until you do.
+            </p>
+            <p style="margin-top: 28px;">
+                <a href="{verify_url}" style="display: inline-block; background: linear-gradient(45deg, #667eea, #764ba2); color: #fff; padding: 12px 28px; border-radius: 999px; text-decoration: none; font-weight: 600;">Confirm subscription</a>
+            </p>
+            <p style="font-size: 12px; opacity: 0.5; margin-top: 32px;">If you didn't sign up, just ignore this email.</p>
+        </div>
+    </body>
+    </html>
+    """
+    text = (
+        f"Confirm your Voyager 2 subscription by opening this link:\n\n"
+        f"{verify_url}\n\n"
+        f"If you didn't sign up, ignore this email."
+    )
+
+    msg.attach(MIMEText(text, "plain"))
+    msg.attach(MIMEText(html, "html"))
+
+    with smtplib.SMTP(SMTP_HOST, SMTP_PORT) as server:
+        server.starttls()
+        server.login(SMTP_USER, SMTP_PASS)
+        server.send_message(msg)
+
+
 def send_email(to_email, subject, unit=None, distance_km=None):
     """Send an HTML email with a beautiful template"""
     msg = MIMEMultipart("alternative")

--- a/app/main.py
+++ b/app/main.py
@@ -1,13 +1,19 @@
+import os
+import secrets
+
 from fastapi import FastAPI, HTTPException
+from fastapi.responses import HTMLResponse
 from pydantic import BaseModel, EmailStr
 from . import models, database
 from . import scheduler
 from sqlalchemy.orm import Session
 from fastapi.middleware.cors import CORSMiddleware
 from .distance_fetcher import get_voyager2_distance_from_earth
-from .emailer import send_email
+from .emailer import send_email, send_verification_email
 
 models.Base.metadata.create_all(bind=database.engine)
+
+APP_BASE_URL = os.getenv("APP_BASE_URL", "https://voyager2-reminder.fly.dev").rstrip("/")
 
 app = FastAPI()
 scheduler.start()
@@ -23,7 +29,7 @@ class UserIn(BaseModel):
     email: EmailStr
     unit: str
 
-@app.post("/register")
+@app.post("/register", status_code=202)
 def register(user: UserIn):
     db: Session = database.SessionLocal()
     if db.query(models.User).filter_by(email=user.email).first():
@@ -32,11 +38,44 @@ def register(user: UserIn):
     if user.unit not in ["light_second", "light_minute", "light_hour"]:
         raise HTTPException(status_code=400, detail="Invalid unit")
 
-    new_user = models.User(email=user.email, unit=user.unit)
+    token = secrets.token_urlsafe(32)
+    new_user = models.User(email=user.email, unit=user.unit, verify_token=token)
     db.add(new_user)
     db.commit()
-    db.refresh(new_user)
-    return {"message": "User registered", "user": user}
+
+    verify_url = f"{APP_BASE_URL}/verify?token={token}"
+    try:
+        send_verification_email(user.email, verify_url)
+    except Exception:
+        db.delete(new_user)
+        db.commit()
+        raise HTTPException(status_code=502, detail="Could not send verification email; please try again.")
+
+    return {"message": "Check your inbox to confirm your subscription."}
+
+
+@app.get("/verify", response_class=HTMLResponse)
+def verify(token: str):
+    db: Session = database.SessionLocal()
+    user = db.query(models.User).filter_by(verify_token=token).first()
+    if not user:
+        return HTMLResponse(
+            """<html><body style="font-family:sans-serif;text-align:center;padding:60px 20px;background:#0a0a0a;color:#fff;">
+            <h1>Invalid or expired link</h1>
+            <p>This confirmation link is no longer valid.</p>
+            </body></html>""",
+            status_code=400,
+        )
+    user.verified = True
+    user.verify_token = None
+    db.commit()
+    return HTMLResponse(
+        f"""<html><body style="font-family:sans-serif;text-align:center;padding:60px 20px;background:#0a0a0a;color:#fff;">
+        <div style="font-size:60px">🚀</div>
+        <h1 style="font-weight:300">You're confirmed</h1>
+        <p>You'll get an email each time Voyager 2 moves another {user.unit.replace('_', ' ')}.</p>
+        </body></html>"""
+    )
 
 @app.delete("/users/{user_id}")
 def delete_user(user_id: int):

--- a/app/models.py
+++ b/app/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Float
+from sqlalchemy import Column, Integer, String, Float, Boolean
 from .database import Base
 
 class User(Base):
@@ -7,3 +7,5 @@ class User(Base):
     email = Column(String, unique=True, index=True)
     unit = Column(String)  # e.g., "light_second", "light_hour"
     last_notified_distance = Column(Float, default=0.0)
+    verified = Column(Boolean, default=False, nullable=False)
+    verify_token = Column(String, nullable=True, index=True)

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -16,7 +16,7 @@ def check_and_notify():
     db = SessionLocal()
     current_distance = get_voyager2_distance_from_earth()
 
-    users = db.query(User).all()
+    users = db.query(User).filter_by(verified=True).all()
     for user in users:
         unit_km = DISTANCE_UNITS.get(user.unit)
         if not unit_km:

--- a/env.example
+++ b/env.example
@@ -5,6 +5,9 @@ SMTP_USER=your-email@gmail.com
 SMTP_PASS=your-app-password
 FROM_EMAIL=your-email@gmail.com
 
+# Public base URL of this service, used to build confirmation links in emails.
+APP_BASE_URL=https://voyager2-reminder.fly.dev
+
 # Database (read by app/database.py)
 # Default for Fly.io with the mounted "db" volume:
 DATABASE_URL=sqlite:////data/users.db


### PR DESCRIPTION
## Summary
- Add a double opt-in flow: \`POST /register\` now stores the user unverified with a one-time token and sends a confirmation email; \`GET /verify?token=...\` flips them to verified.
- Scheduler only notifies verified users.
- Failed sends roll back the user row so we don't leak unverified records.

## Context
Without confirmation, anyone could subscribe anyone else's email — the scheduler would spam them every 4 h and Brevo would eventually flag the account.

## Changes
- \`app/models.py\`: + \`verified\` (bool) and \`verify_token\` (str)
- \`app/emailer.py\`: new \`send_verification_email(to, url)\`
- \`app/main.py\`: + \`APP_BASE_URL\` constant; rewrote \`/register\` to issue a token + email; new \`/verify\` HTML route
- \`app/scheduler.py\`: filter by \`verified=True\`
- \`env.example\`: document \`APP_BASE_URL\`

## Operational steps after merge
1. Drop the users table (its schema is now stale — \`create_all\` doesn't ALTER):
   \`\`\`
   fly ssh console -a voyager2-reminder -C "python -c 'import sqlite3; sqlite3.connect(\"/data/users.db\").execute(\"DROP TABLE IF EXISTS users\").connection.commit()'"
   \`\`\`
   The DB is empty so no data loss.
2. \`fly deploy\` — boot creates the table fresh with the new columns.
3. (Optional) \`fly secrets set APP_BASE_URL=https://voyager2-reminder.fly.dev -a voyager2-reminder\` — only needed if you bind a custom domain. The hardcoded default already matches the current Fly hostname.

## Test plan
- [ ] Register via the live frontend → 202, success copy says "Check your inbox"
- [ ] Confirmation email arrives via Brevo with the verify link
- [ ] Click the link → "You're confirmed" page renders
- [ ] DB shows \`verified=1\` and \`verify_token=NULL\`
- [ ] Trying the same link again → "Invalid or expired link" (because token was cleared)
- [ ] Wait or force-trigger the scheduler — only the verified user receives a notification